### PR TITLE
wall following

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.8)
+project(self_drive)
+
+
+set(CMAKE_CXX_STANDARD 17)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(example_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+
+add_executable(self_drive src/self_drive.cpp)
+ament_target_dependencies(self_drive
+ rclcpp
+ geometry_msgs
+ sensor_msgs
+ nav_msgs)
+
+install(TARGETS self_drive
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/pakage.xml
+++ b/pakage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>self_drive</name>
+  <version>0.1.0</version>
+  <description>ROS 2 package to test simple service communication based on rclcpp</description>
+  <author email="yjwdragon@naver.com">jungwoo</author>
+  <maintainer email="jksil200@naver.com">jaehun</maintainer>
+  <license>MIT License</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+ <depend>nav_msgs</depend>
+
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/wall_follow.cpp
+++ b/wall_follow.cpp
@@ -6,6 +6,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 using namespace std::chrono_literals;
 
@@ -14,15 +15,15 @@ class SelfDrive : public rclcpp::Node
   rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
   int step_;
-  bool wall_following_;  // Flag to indicate whether the turtle is wall following
 
 public:
-  SelfDrive() : rclcpp::Node("self_drive"), step_(0), wall_following_(false)
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0)
   {
     auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
     lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
     auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
-    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile, callback);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile,
+                                                                       callback);
     auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
     pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
   }
@@ -30,71 +31,32 @@ public:
   void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
   {
     geometry_msgs::msg::Twist vel;
-
-    // Check if an obstacle is near (within 25cm)
-    if (is_obstacle_near(scan, 0.25))
+    if (scan->ranges[0] < 0.25 || scan->ranges[20] < 0.25)
     {
-      // Obstacle detected nearby, rotate to avoid obstacle
       vel.linear.x = 0.;
-      vel.angular.z = 0.5;  // Rotate to avoid the obstacle
-      wall_following_ = false;  // Stop wall following
+      vel.angular.z = -0.5;
     }
-    else if (wall_following_)
+    else if(scan->ranges[20] < 0.25 || scan->ranges[40] < 0.25)
     {
-      // Wall following mode
-      vel.linear.x = std::max(0.15, 0.1);  // Maintain a minimum linear speed of 15cm/s
-      vel.angular.z = calculate_angular_velocity(scan, 35.0);  // Follow the wall
+      vel.linear.x = 0.15;
+      vel.angular.z = -0.01;
+    }
+    else if(scan->ranges[40] < 0.25 || scan->ranges[60] < 0.25)
+    {
+       vel.linear.x = 0.15;
+      vel.angular.z = -0.01;
     }
     else
     {
-      // Initial mode: Move forward until a wall is detected
-      vel.linear.x = 0.2;
+      vel.linear.x = 0.15;
       vel.angular.z = 0.;
-      if (is_wall_in_front(scan, 0.5))
-      {
-        // Wall detected in front, switch to wall following mode
-        wall_following_ = true;
-      }
     }
-
+    
     RCLCPP_INFO(rclcpp::get_logger("self_drive"),
-                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f, wall_following=%d",
-                step_, scan->ranges[0], vel.linear.x, vel.angular.z, static_cast<int>(wall_following_));
-
+                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f", step_, scan->ranges[0],
+                vel.linear.x, vel.angular.z);
     pose_pub_->publish(vel);
     step_++;
-  }
-
-private:
-  bool is_obstacle_near(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
-  {
-    // Check if there is an obstacle nearby
-    for (auto range : scan->ranges)
-    {
-      if (range < threshold)
-      {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool is_wall_in_front(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
-  {
-    // Check if there is a wall in front of the turtle
-    return scan->ranges[0] < threshold;
-  }
-
-  double calculate_angular_velocity(const sensor_msgs::msg::LaserScan::SharedPtr scan, double target_distance)
-  {
-    double wall_distance = scan->ranges[0];  // Distance to the wall in front of the turtle
-    double error = wall_distance - target_distance;
-
-    // P-controller for wall following
-    double kp = 0.1;  // Proportional gain
-    double angular_velocity = kp * error;
-
-    return angular_velocity;
   }
 };
 
@@ -106,4 +68,3 @@ int main(int argc, char* argv[])
   rclcpp::shutdown();
   return 0;
 }
-

--- a/wall_follow.cpp
+++ b/wall_follow.cpp
@@ -34,24 +34,18 @@ public:
     if (scan->ranges[0] < 0.25 || scan->ranges[20] < 0.25)
     {
       vel.linear.x = 0.;
-      vel.angular.z = -0.5;
+      vel.angular.z = -1.;
     }
-    else if(scan->ranges[20] < 0.25 || scan->ranges[40] < 0.25)
+    else if(scan->ranges[75] < 0.4 && !(scan->ranges[45] < 0.25))
     {
       vel.linear.x = 0.15;
-      vel.angular.z = -0.01;
-    }
-    else if(scan->ranges[40] < 0.25 || scan->ranges[60] < 0.25)
-    {
-       vel.linear.x = 0.15;
-      vel.angular.z = -0.01;
-    }
+      vel.angular.z = 4.;
+    }    
     else
     {
       vel.linear.x = 0.15;
       vel.angular.z = 0.;
     }
-    
     RCLCPP_INFO(rclcpp::get_logger("self_drive"),
                 "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f", step_, scan->ranges[0],
                 vel.linear.x, vel.angular.z);

--- a/wall_follow.cpp
+++ b/wall_follow.cpp
@@ -1,0 +1,109 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+using namespace std::chrono_literals;
+
+class SelfDrive : public rclcpp::Node
+{
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
+  int step_;
+  bool wall_following_;  // Flag to indicate whether the turtle is wall following
+
+public:
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0), wall_following_(false)
+  {
+    auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile, callback);
+    auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
+  }
+
+  void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
+  {
+    geometry_msgs::msg::Twist vel;
+
+    // Check if an obstacle is near (within 25cm)
+    if (is_obstacle_near(scan, 0.25))
+    {
+      // Obstacle detected nearby, rotate to avoid obstacle
+      vel.linear.x = 0.;
+      vel.angular.z = 0.5;  // Rotate to avoid the obstacle
+      wall_following_ = false;  // Stop wall following
+    }
+    else if (wall_following_)
+    {
+      // Wall following mode
+      vel.linear.x = std::max(0.15, 0.1);  // Maintain a minimum linear speed of 15cm/s
+      vel.angular.z = calculate_angular_velocity(scan, 35.0);  // Follow the wall
+    }
+    else
+    {
+      // Initial mode: Move forward until a wall is detected
+      vel.linear.x = 0.2;
+      vel.angular.z = 0.;
+      if (is_wall_in_front(scan, 0.5))
+      {
+        // Wall detected in front, switch to wall following mode
+        wall_following_ = true;
+      }
+    }
+
+    RCLCPP_INFO(rclcpp::get_logger("self_drive"),
+                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f, wall_following=%d",
+                step_, scan->ranges[0], vel.linear.x, vel.angular.z, static_cast<int>(wall_following_));
+
+    pose_pub_->publish(vel);
+    step_++;
+  }
+
+private:
+  bool is_obstacle_near(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
+  {
+    // Check if there is an obstacle nearby
+    for (auto range : scan->ranges)
+    {
+      if (range < threshold)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool is_wall_in_front(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
+  {
+    // Check if there is a wall in front of the turtle
+    return scan->ranges[0] < threshold;
+  }
+
+  double calculate_angular_velocity(const sensor_msgs::msg::LaserScan::SharedPtr scan, double target_distance)
+  {
+    double wall_distance = scan->ranges[0];  // Distance to the wall in front of the turtle
+    double error = wall_distance - target_distance;
+
+    // P-controller for wall following
+    double kp = 0.1;  // Proportional gain
+    double angular_velocity = kp * error;
+
+    return angular_velocity;
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<SelfDrive>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}
+


### PR DESCRIPTION
이 브랜치는 벽을 마주하게 되면 정지하고 벽을 따라가게 하기 위한 코드를 만들기 위해 제작되었다.
전방 25cm 이하의 거리에서 벽을 인식한다.
벽이 있을 경우 정지하고 좌회전을 하고 wall_following을 false로 설정한다.
그 이외에는 wall_following 상태를 실행한다.
wall following 상태에서는 0.15의 속도를 이용하여 직진을 하다 벽을 따라 좌회전한다.
그 외에서는 다시 직진한다.
이런식으로 계속 반복하여 직진 후 좌회전을 이용하여 벽을 따라간다.
이 코드에서는 벽을 따라갈 때 wall_following을 true/false 값으로 받아 실행하거나 취소한다.
하지만 이 코드가 제대로 작동하지 않아 wall_following이 아닌 if문을 이용하여 한다.
또한 인식 각도를 다양하게 받아 계속 벽을 인식할 수 있게 해야 한다.